### PR TITLE
chore: Configure Renovate (FIS-17871)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "description": "Security hardening for GitHub Actions (FIS-17871): pin to SHA digests, delay updates 3 days",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "groupName": "GitHub Actions",
+      "minimumReleaseAge": "3 days"
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,9 @@
         "github-actions"
       ],
       "groupName": "GitHub Actions",
-      "minimumReleaseAge": "3 days"
+      "minimumReleaseAge": "3 days",
+      "pinDigests": true
     }
   ]
 }
+


### PR DESCRIPTION
## Reason

Security hardening for GitHub Actions per FIS-17871 — pin actions to SHA digests and delay updates 3 days to allow review window.

## Changes

- Add `renovate.json` with `config:recommended` and a packageRules entry that:
  - Targets `github-actions` manager
  - Groups updates as "GitHub Actions"
  - Applies `minimumReleaseAge: 3 days`

## Test Scopes

- N/A (config-only)

## Checks

- [x] Renovate config matches the FIS-17871 standard applied across the org